### PR TITLE
fix: correct build for `aarch64` platforms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ impl Config {
                 ));
             }
 
-            #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+            #[cfg(target_arch = "aarch64")]
             if pair.size % 4 != 0 {
                 return Err(anyhow!(
                     "the size_percent_pair.size must be a multiple of 4"
@@ -141,7 +141,7 @@ impl Config {
             ));
         }
 
-        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+        #[cfg(target_arch = "aarch64")]
         if self.queue_cap % 8 != 0 {
             return Err(anyhow!("the queue_cap must be a multiple of 8"));
         }
@@ -155,11 +155,7 @@ impl Config {
             return Err(anyhow!("shmipc just support linux OS now"));
         }
 
-        #[cfg(not(any(
-            target_arch = "x86_64",
-            target_arch = "aarch64",
-            target_arch = "arm64ec"
-        )))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         {
             return Err(anyhow!("shmipc just support amd64 or arm64 arch"));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ impl Config {
                 ));
             }
 
-            #[cfg(any(target_arch = "arm", target_arch = "arm64ec"))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
             if pair.size % 4 != 0 {
                 return Err(anyhow!(
                     "the size_percent_pair.size must be a multiple of 4"
@@ -141,7 +141,7 @@ impl Config {
             ));
         }
 
-        #[cfg(any(target_arch = "arm", target_arch = "arm64ec"))]
+        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         if self.queue_cap % 8 != 0 {
             return Err(anyhow!("the queue_cap must be a multiple of 8"));
         }
@@ -155,7 +155,11 @@ impl Config {
             return Err(anyhow!("shmipc just support linux OS now"));
         }
 
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "arm64ec")))]
+        #[cfg(not(any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "arm64ec"
+        )))]
         {
             return Err(anyhow!("shmipc just support amd64 or arm64 arch"));
         }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -132,7 +132,7 @@ impl QueueManager {
         let fi = file.metadata()?;
 
         let mapping_size = fi.len();
-        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+        #[cfg(target_arch = "aarch64")]
         // a queueManager have two queue, a queue's head and tail should align to 8 byte boundary
         if mapping_size % 16 != 0 {
             return Err(anyhow!(
@@ -163,7 +163,7 @@ impl QueueManager {
         let fi = file.metadata()?;
 
         let mapping_size = fi.len();
-        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+        #[cfg(target_arch = "aarch64")]
         // a queueManager have two queue, a queue's head and tail should align to 8 byte boundary
         if mapping_size % 16 != 0 {
             return Err(anyhow!(
@@ -246,7 +246,7 @@ impl Queue {
         let cap = unsafe { *(data as *mut u32) };
         let queue_start_offset = QUEUE_HEADER_LENGTH;
         let queue_end_offset = QUEUE_HEADER_LENGTH + QUEUE_ELEMENT_LEN * cap as usize;
-        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+        #[cfg(target_arch = "aarch64")]
         unsafe {
             Queue {
                 cap: cap as i64,
@@ -259,7 +259,7 @@ impl Queue {
             }
         }
         // TODO: unaligned head and tail
-        #[cfg(not(any(target_arch = "aarch64", target_arch = "arm64ec")))]
+        #[cfg(not(target_arch = "aarch64"))]
         unsafe {
             Self {
                 cap: cap as i64,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -132,7 +132,7 @@ impl QueueManager {
         let fi = file.metadata()?;
 
         let mapping_size = fi.len();
-        #[cfg(any(target_arch = "arm", target_arch = "arm64ec"))]
+        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         // a queueManager have two queue, a queue's head and tail should align to 8 byte boundary
         if mapping_size % 16 != 0 {
             return Err(anyhow!(
@@ -163,7 +163,7 @@ impl QueueManager {
         let fi = file.metadata()?;
 
         let mapping_size = fi.len();
-        #[cfg(any(target_arch = "arm", target_arch = "arm64ec"))]
+        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         // a queueManager have two queue, a queue's head and tail should align to 8 byte boundary
         if mapping_size % 16 != 0 {
             return Err(anyhow!(
@@ -246,7 +246,7 @@ impl Queue {
         let cap = unsafe { *(data as *mut u32) };
         let queue_start_offset = QUEUE_HEADER_LENGTH;
         let queue_end_offset = QUEUE_HEADER_LENGTH + QUEUE_ELEMENT_LEN * cap as usize;
-        #[cfg(any(target_arch = "arm", target_arch = "arm64ec"))]
+        #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         unsafe {
             Queue {
                 cap: cap as i64,
@@ -255,10 +255,11 @@ impl Queue {
                 tail: data.offset(16) as *mut i64,
                 queue_bytes_on_memory: data.offset(queue_start_offset as isize) as *const u8,
                 len: queue_end_offset - queue_start_offset,
+                lock: Mutex::new(()),
             }
         }
         // TODO: unaligned head and tail
-        #[cfg(not(any(target_arch = "arm", target_arch = "arm64ec")))]
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "arm64ec")))]
         unsafe {
             Self {
                 cap: cap as i64,


### PR DESCRIPTION
This PR fixes build failures on the `aarch64` architecture by:

- Using `aarch64` instead of `arm` as the correct conditional compilation flag for the 64-bit ARM target.

- Adding the missing `lock` field during the construction of the `Queue` struct for `aarch64` or `arm64ec` targets. 

Closes #1 