### PR TITLE
feat: introduce tokio compact StreamExt and remove AsyncOpShm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shmipc"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,20 +35,13 @@ rand = "0.9"
 tokio-scoped = "0.2"
 tracing-subscriber = "0.3"
 
-
-[profile.dev]
-overflow-checks = false
-
 [profile.release]
 opt-level = 3
 debug = true
 rpath = false
 lto = true
-debug-assertions = false
 codegen-units = 1
 panic = 'unwind'
-incremental = false
-overflow-checks = false
 
 [workspace]
 members = ["examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shmipc"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 authors = ["Volo Team <volo@cloudwego.io>"]
 license = "Apache-2.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,10 +16,12 @@ use std::os::unix::net::SocketAddr;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use shmipc::{
-    AsyncReadShm, AsyncWriteShm, BufferReader, BufferSlice, Error, LinkedBuffer, Listener,
-    SessionManager, SessionManagerConfig, Stream,
+    Error, Listener,
+    buffer::{BufferReader, BufferSlice, LinkedBuffer},
     config::SizePercentPair,
     consts::MemMapType,
+    session::{SessionManager, SessionManagerConfig},
+    stream::Stream,
     transport::{DefaultUnixConnect, DefaultUnixListen},
 };
 use tokio::{
@@ -93,7 +95,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         loop {
                             tokio::select! {
                                 r = server.accept() => {
-                                    let mut stream = r.unwrap().unwrap();
+                                    let mut stream = r.unwrap();
                                     tokio::spawn(async move {
                                         loop {
                                             if !must_read(&mut stream, size).await {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,5 +17,13 @@ name = "greeter_client"
 path = "src/hello_world/greeter_client.rs"
 
 [[bin]]
+name = "greeter_client_tokio"
+path = "src/hello_world/greeter_client_tokio.rs"
+
+[[bin]]
 name = "greeter_server"
 path = "src/hello_world/greeter_server.rs"
+
+[[bin]]
+name = "greeter_server_tokio"
+path = "src/hello_world/greeter_server_tokio.rs"

--- a/src/buffer/list.rs
+++ b/src/buffer/list.rs
@@ -438,15 +438,14 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_create_free_buffer_list() {
-        assert!(
-            BufferList::create(
-                4294967295,
-                4294967295,
-                &MmapOptions::new().len(1).map_anon().unwrap(),
-                4294967279
-            )
-            .is_err()
+        BufferList::create(
+            4294967295,
+            4294967295,
+            &MmapOptions::new().len(1).map_anon().unwrap(),
+            4294967279,
         )
+        .unwrap_err();
     }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod buf;
+mod buf;
 pub mod linked;
 pub mod list;
 pub mod manager;
 pub mod slice;
 
-use buf::Buf;
+pub use buf::Buf;
+pub use linked::LinkedBuffer;
+pub use slice::BufferSlice;
 
 use crate::error::Error;
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,0 +1,195 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::{buffer::Buf, error::Error, stream::Stream};
+
+/// [`Stream`] compatible with [`AsyncRead`] and [`AsyncWrite`].
+pub struct StreamExt {
+    inner: Stream,
+
+    read_state: ReadState,
+    write_state: WriteState,
+}
+
+impl StreamExt {
+    pub const fn new(inner: Stream) -> Self {
+        Self {
+            inner,
+            read_state: ReadState::Idle,
+            write_state: WriteState::Idle,
+        }
+    }
+
+    pub const fn inner(&self) -> &Stream {
+        &self.inner
+    }
+
+    pub const fn inner_mut(&mut self) -> &mut Stream {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> Stream {
+        self.inner
+    }
+}
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
+
+enum ReadState {
+    Idle,
+    Reading(BoxFuture<'static, Result<Buf<'static>, Error>>),
+    Consuming(crate::util::shmbuf_reader::BufReader),
+}
+
+enum WriteState {
+    Idle,
+    Flushing(BoxFuture<'static, Result<(), Error>>),
+    Closing(BoxFuture<'static, Result<(), Error>>),
+}
+
+impl AsyncRead for StreamExt {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.read_state {
+                ReadState::Idle => {
+                    if buf.remaining() == 0 {
+                        return Poll::Ready(Ok(()));
+                    }
+                    let fut = this.inner.read();
+                    let fut: BoxFuture<'_, Result<Buf<'_>, Error>> = Box::pin(fut);
+                    // Safety:
+                    // The `fut` returned by `inner.read` captures the lifetime of `inner`.
+                    // Since `fut` is stored in `self.read_state` and `self` is pinned, `inner` will
+                    // remain valid as long as `fut` exists. We use `transmute`
+                    // to erase the lifetime, satisfying the static requirement
+                    // of `BoxFuture`.
+                    let fut: BoxFuture<'static, Result<Buf<'static>, Error>> =
+                        unsafe { std::mem::transmute(fut) };
+                    this.read_state = ReadState::Reading(fut);
+                }
+                ReadState::Reading(fut) => {
+                    let res = ready!(fut.as_mut().poll(cx));
+                    match res {
+                        Ok(b) => {
+                            this.read_state =
+                                ReadState::Consuming(crate::util::shmbuf_reader::BufReader::new(b));
+                        }
+                        Err(e) => {
+                            this.read_state = ReadState::Idle;
+                            return Poll::Ready(Err(e.into()));
+                        }
+                    }
+                }
+                ReadState::Consuming(reader) => {
+                    if reader.read(buf) {
+                        this.read_state = ReadState::Idle;
+                    }
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for StreamExt {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let this = self.get_mut();
+        Poll::Ready(this.inner.write_bytes(buf).map_err(Into::into))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+
+        loop {
+            match &mut this.write_state {
+                WriteState::Idle => {
+                    let fut = this.inner.flush(true);
+                    let fut: BoxFuture<'_, Result<(), Error>> = Box::pin(fut);
+                    // Safety:
+                    // Similar to poll_read, `fut` captures `inner`. `inner` is pinned via `self`.
+                    let fut: BoxFuture<'static, Result<(), Error>> =
+                        unsafe { std::mem::transmute(fut) };
+                    this.write_state = WriteState::Flushing(fut);
+                }
+                WriteState::Flushing(fut) => {
+                    let res = ready!(fut.as_mut().poll(cx));
+                    this.write_state = WriteState::Idle;
+                    match res {
+                        Ok(_) | Err(Error::StreamClosed) => return Poll::Ready(Ok(())),
+                        Err(e) => return Poll::Ready(Err(e.into())),
+                    }
+                }
+                WriteState::Closing(_) => {
+                    return Poll::Ready(Err(std::io::Error::other(
+                        "close in progress during flush",
+                    )));
+                }
+            }
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+
+        loop {
+            match &mut this.write_state {
+                WriteState::Idle => {
+                    let fut = this.inner.close();
+                    let fut: BoxFuture<'_, Result<(), Error>> = Box::pin(fut);
+                    // Safety:
+                    // Similar to poll_read, `fut` captures `inner`. `inner` is pinned via `self`.
+                    let fut: BoxFuture<'static, Result<(), Error>> =
+                        unsafe { std::mem::transmute(fut) };
+                    this.write_state = WriteState::Closing(fut);
+                }
+                WriteState::Closing(fut) => {
+                    let res = ready!(fut.as_mut().poll(cx));
+                    this.write_state = WriteState::Idle;
+                    match res {
+                        Ok(_) => return Poll::Ready(Ok(())),
+                        Err(e) => {
+                            return Poll::Ready(Err(e.into()));
+                        }
+                    }
+                }
+                WriteState::Flushing(_) => {
+                    // If we are flushing, we need to drive the flush to completion first.
+                    // Since we are in poll_shutdown, and it requires a mutable reference,
+                    // and poll_flush also requires one, we can't easily call self.poll_flush(cx).
+                    // Instead, we just poll the existing flush future directly here.
+
+                    // Note: We rely on the loop to re-enter this match arm.
+                    // However, the Flushing state holds a future that needs to be polled.
+                    // We can extract the future temporarily or match on it.
+                    // But wait, `this.write_state` is `&mut WriteState`.
+                    let WriteState::Flushing(fut) = &mut this.write_state else {
+                        unreachable!();
+                    };
+                    let res = ready!(fut.as_mut().poll(cx));
+                    this.write_state = WriteState::Idle;
+                    if let Err(e) = res {
+                        return Poll::Ready(Err(e.into()));
+                    }
+                    // Flush completed, continue loop to start closing
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ pub struct SizePercentPair {
     pub percent: u32,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 /// Config is used to tune the shmipc session
 pub struct Config {
     /// connection_write_timeout is meant to be a "safety value" timeout after
@@ -69,12 +69,6 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Config {
-    pub fn new() -> Self {
         Self {
             connection_write_timeout: Duration::from_secs(10),
             connection_read_timeout: None,
@@ -89,6 +83,12 @@ impl Config {
             rebuild_interval: SESSION_REBUILD_INTERVAL,
             max_stream_num: 4096,
         }
+    }
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn verify(&self) -> Result<(), anyhow::Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// InvalidVersion means that we received a frame with an invalid version.
     #[error("invalid protocol version")]
@@ -145,4 +148,44 @@ pub enum Error {
 
     #[error(transparent)]
     Others(#[from] anyhow::Error),
+}
+
+impl From<Error> for io::Error {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::InvalidVersion => io::Error::new(io::ErrorKind::InvalidData, value),
+            Error::InvalidMsgType => io::Error::new(io::ErrorKind::InvalidData, value),
+            Error::SessionShutdown => io::Error::new(io::ErrorKind::ConnectionReset, value),
+            Error::StreamsExhausted => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::DuplicateStream => io::Error::new(io::ErrorKind::AlreadyExists, value),
+            Error::Timeout => io::Error::new(io::ErrorKind::TimedOut, value),
+            Error::StreamClosed => io::Error::new(io::ErrorKind::ConnectionAborted, value),
+            Error::StreamReset => io::Error::new(io::ErrorKind::ConnectionReset, value),
+            Error::ConnectionWriteTimeout => io::Error::new(io::ErrorKind::InvalidData, value),
+            Error::ConnectionTimeout => io::Error::new(io::ErrorKind::TimedOut, value),
+            Error::KeepAliveTimeout => io::Error::new(io::ErrorKind::TimedOut, value),
+            Error::EndOfStream => io::Error::new(io::ErrorKind::UnexpectedEof, value),
+            Error::SessionUnhealthy => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::NotEnoughData => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::NoMoreBuffer => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::SizeTooLarge => io::Error::new(io::ErrorKind::OutOfMemory, value),
+            Error::BrokenBuffer => io::Error::new(io::ErrorKind::BrokenPipe, value),
+            Error::ShareMemoryHadNotLeftSpace => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::StreamCallbackHadExisted => io::Error::new(io::ErrorKind::AlreadyExists, value),
+            Error::ExchangeConfig => io::Error::other(value),
+            Error::ExchangeConfigTimeout => io::Error::new(io::ErrorKind::TimedOut, value),
+            Error::OSNonSupported => io::Error::new(io::ErrorKind::Unsupported, value),
+            Error::ArchNonSupported => io::Error::new(io::ErrorKind::Unsupported, value),
+            Error::HotRestartInProgress => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::InHandshakeStage => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::FileNameTooLong => io::Error::new(io::ErrorKind::InvalidInput, value),
+            Error::QueueEmpty => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::QueueFull => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::StreamPoolFull => io::Error::new(io::ErrorKind::ResourceBusy, value),
+            Error::StreamHasUnreadData(_) => io::Error::other(value),
+            Error::StreamHasPendingData(_) => io::Error::other(value),
+            Error::Io(io) => io,
+            Error::Others(err) => io::Error::other(err),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,24 +14,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod buffer;
 mod error;
 mod listener;
 mod protocol;
 mod queue;
-mod session;
-mod stream;
 mod util;
 
+pub mod buffer;
+pub mod compact;
 pub mod config;
 pub mod consts;
+pub mod session;
 pub mod stats;
+pub mod stream;
 pub mod transport;
 
-pub use self::{
-    buffer::{BufferReader, BufferWriter, linked::LinkedBuffer, slice::BufferSlice},
-    error::Error,
-    listener::Listener,
-    session::{config::SessionManagerConfig, manager::SessionManager},
-    stream::{AsyncReadShm, AsyncWriteShm, Stream},
-};
+pub use self::{error::Error, listener::Listener};

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use crate::config::Config;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct SessionManagerConfig {
     config: Config,
     session_num: usize,

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -112,10 +112,10 @@ where
         Ok(sm)
     }
 
-    /// Return a shmipc's stream from stream pool.
+    /// Get a ShmIPC's [`Stream`] from pool.
     ///
-    /// Every stream should explicitly call `put_back()` to return it to SessionManager for next
-    /// time using, otherwise it will cause resource leak.
+    /// NOTE: after using the [`Stream`], you MUST explicitly call `stream.reuse().await` for
+    /// releasing it, otherwise it will cause resource leak.
     pub fn get_stream(&self) -> Result<Stream, Error> {
         let sessions = &self.inner.sessions;
         if sessions.is_empty() {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -112,6 +112,7 @@ impl TransportListen for DefaultUnixListen {
                 "unnamed unix domain socket cannot be listened",
             ));
         };
+        let _ = nix::unistd::unlink(path);
         UnixListener::bind(path)
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod buf_reader;
+pub mod shmbuf_reader;
 
 /// Determine whether to create new share memory based on the current remaining share memory size.
 ///

--- a/src/util/shmbuf_reader.rs
+++ b/src/util/shmbuf_reader.rs
@@ -1,0 +1,85 @@
+use crate::buffer::Buf;
+
+pub struct BufReader {
+    buf: Buf<'static>,
+    consumed: usize,
+}
+
+impl BufReader {
+    pub const fn new(buf: Buf<'static>) -> Self {
+        Self { buf, consumed: 0 }
+    }
+
+    // return true: all data is consumed
+    pub fn read(&mut self, buf: &mut tokio::io::ReadBuf<'_>) -> bool {
+        tracing::trace!(
+            "ShmBufReader: buf.len = {}, consumed = {}, read.remaining = {}",
+            self.buf.len(),
+            self.consumed,
+            buf.remaining()
+        );
+        if self.consumed >= self.buf.len() {
+            return true;
+        }
+        let inner = &self.buf[self.consumed..];
+        if inner.len() <= buf.remaining() {
+            buf.put_slice(inner);
+            self.consumed += inner.len();
+            return true;
+        }
+        let read_len = buf.remaining();
+        buf.put_slice(&inner[..read_len]);
+        self.consumed += read_len;
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+
+    use super::BufReader;
+    use crate::buffer::Buf;
+
+    const BUF_LEN: usize = 64;
+    const READ_SIZE: usize = 16;
+
+    fn shm_buf(size: usize) -> Buf<'static> {
+        let mut buf = BytesMut::with_capacity(size);
+        // SAFETY: just for testing
+        unsafe { buf.set_len(size) };
+        Buf::Exm(buf.freeze())
+    }
+
+    #[test]
+    fn test_nothing() {
+        let mut buf = [0u8; 64];
+        let mut readbuf = tokio::io::ReadBuf::new(&mut buf);
+        let mut reader = BufReader::new(shm_buf(0));
+        assert!(reader.read(&mut readbuf));
+        assert_eq!(reader.consumed, 0);
+    }
+
+    #[test]
+    fn test_read_once() {
+        let mut buf = [0u8; BUF_LEN];
+        let mut readbuf = tokio::io::ReadBuf::new(&mut buf);
+        let mut reader = BufReader::new(shm_buf(READ_SIZE));
+        assert!(reader.read(&mut readbuf));
+        assert_eq!(reader.consumed, READ_SIZE);
+    }
+
+    #[test]
+    fn test_read_twice() {
+        const DATA_LEN: usize = BUF_LEN + READ_SIZE;
+
+        let mut buf = [0u8; BUF_LEN];
+        let mut readbuf = tokio::io::ReadBuf::new(&mut buf);
+        let mut reader = BufReader::new(shm_buf(80));
+        assert!(!reader.read(&mut readbuf));
+        assert_eq!(reader.consumed, BUF_LEN);
+        readbuf.clear();
+        assert!(reader.read(&mut readbuf));
+        assert_eq!(reader.consumed, DATA_LEN);
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,10 +18,12 @@ use std::{
 };
 
 use shmipc::{
-    AsyncReadShm, AsyncWriteShm, BufferReader, BufferSlice, Error, LinkedBuffer, Listener,
-    SessionManager, SessionManagerConfig, Stream,
+    Error, Listener,
+    buffer::{BufferReader, BufferSlice, LinkedBuffer},
     config::SizePercentPair,
     consts::MemMapType,
+    session::{SessionManager, SessionManagerConfig},
+    stream::Stream,
     transport::{DefaultUnixConnect, DefaultUnixListen},
 };
 
@@ -62,7 +64,7 @@ async fn test_ping_pong_by_shmipc() {
 
     tokio_scoped::scope(|s| {
         s.spawn(async move {
-            let mut stream = server.accept().await.unwrap().unwrap();
+            let mut stream = server.accept().await.unwrap();
             must_read(&mut stream, size).await;
             stream.recv_buf().release_previous_read();
             must_write(&mut stream, size).await;


### PR DESCRIPTION
## Motivation

Given the strong coupling between `AsyncReadShm` & `AsyncWriteShm` and `Stream`, and the need to explicitly call related `Stream` interfaces (such as `close` and `reuse`) after using the interfaces of AsyncOpShm, abstracting those traits is unnecessary.

However, for compatibility with `AsyncRead` and `AsyncWrite` of TokIO, we added `StreamExt` to provide implementations for `AsyncRead` and `AsyncWrite`. But since explicit calls to `Stream`'s interfaces are still required in this case, we added detailed documentation to `StreamExt` to remind users of this.

## Solution

- Remove `AsyncReadShm` and `AsyncWriteShm`
- Introduce `StreamExt` which implements `AsyncRead` and `AsyncWrite` of TokIO
