### PR TITLE
Fix shared-memory buffer edge cases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: exit 0
 
   lint:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
           cargo +nightly fmt --all -- --check
 
   docs-check:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
           cargo rustdoc --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
 
   test-linux:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v4

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -7,7 +7,7 @@ on:
       - "**/Cargo.lock"
 jobs:
   security-audit:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/src/buffer/manager.rs
+++ b/src/buffer/manager.rs
@@ -121,6 +121,12 @@ impl BufferManager {
         } else {
             let f_info = nix::sys::stat::fstat(unsafe { BorrowedFd::borrow_raw(memfd) })
                 .map_err(|err| anyhow!("BufferManager get_with_memfd mapping failed: {}", err))?;
+            if f_info.st_size < 0 || f_info.st_size > u32::MAX as i64 {
+                return Err(anyhow!(
+                    "BufferManager get_with_memfd invalid share memory size: {}",
+                    f_info.st_size
+                ));
+            }
             capacity = f_info.st_size as u32;
         }
 
@@ -186,7 +192,14 @@ impl BufferManager {
             let fi = shm_file
                 .metadata()
                 .map_err(|err| anyhow!("get_global_buffer_manager mapping failed, {err}"))?;
-            capacity = fi.len() as u32;
+            let sz = fi.len();
+            if sz > u32::MAX as u64 {
+                return Err(anyhow!(
+                    "get_global_buffer_manager invalid share memory size: {}",
+                    sz
+                ));
+            }
+            capacity = sz as u32;
             shm_file
         };
 
@@ -410,6 +423,27 @@ impl BufferManager {
 
     pub fn recycle_buffer(&self, slice: BufferSlice) {
         if slice.is_from_shm {
+            let Some(buffer_header) = &slice.buffer_header else {
+                tracing::warn!(
+                    "skip recycling shm buffer without header: path={} offset={} cap={} size={}",
+                    self.path,
+                    slice.offset_in_shm,
+                    slice.cap,
+                    slice.size()
+                );
+                return;
+            };
+            if !buffer_header.is_in_used() {
+                tracing::warn!(
+                    "skip recycling shm buffer that is not in use: path={} offset={} cap={} \
+                     size={}",
+                    self.path,
+                    slice.offset_in_shm,
+                    slice.cap,
+                    slice.size()
+                );
+                return;
+            }
             for list in self.lists.iter() {
                 if slice.cap == unsafe { *list.cap_per_buffer } {
                     list.push(slice);
@@ -507,7 +541,7 @@ impl BufferManager {
     pub fn check_buffer_returned(&self) -> bool {
         for list in self.lists.iter() {
             unsafe {
-                if (*list.size).load(Ordering::SeqCst) as u32 != (*list.cap).load(Ordering::SeqCst)
+                if (*list.size).load(Ordering::SeqCst) != (*list.cap).load(Ordering::SeqCst) as i32
                 {
                     return false;
                 }
@@ -554,6 +588,9 @@ impl BufferManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
+    use memmap2::MmapOptions;
     use rand::Rng;
 
     use super::{BufferManager, SizePercentPair};
@@ -714,5 +751,51 @@ mod tests {
         linked_buffer_slices.done(false);
         bm.recycle_buffers(linked_buffer_slices.slice_list_mut().pop_front().unwrap());
         assert_eq!(num_of_slice, bm.slice_size());
+    }
+
+    #[test]
+    fn test_buffer_manager_skip_duplicate_recycle() {
+        let mem = MmapOptions::new().len(1 << 20).map_anon().unwrap();
+        let bm = BufferManager::create(
+            &[SizePercentPair {
+                size: 4096,
+                percent: 100,
+            }],
+            "",
+            mem,
+            0,
+        )
+        .unwrap();
+        let list = bm.lists[0];
+        let original_size = unsafe { (*list.size).load(Ordering::SeqCst) };
+        let original_counter = unsafe { (*list.counter).load(Ordering::SeqCst) };
+
+        let slice = bm.alloc_shm_buffer(4096).unwrap();
+        let offset = slice.offset_in_shm;
+        let alias = bm.read_buffer_slice(offset).unwrap();
+
+        assert_eq!(original_size - 1, unsafe {
+            (*list.size).load(Ordering::SeqCst)
+        });
+        assert_eq!(original_counter + 1, unsafe {
+            (*list.counter).load(Ordering::SeqCst)
+        });
+
+        bm.recycle_buffer(slice);
+        assert_eq!(original_size, unsafe {
+            (*list.size).load(Ordering::SeqCst)
+        });
+        assert_eq!(original_counter, unsafe {
+            (*list.counter).load(Ordering::SeqCst)
+        });
+
+        bm.recycle_buffer(alias);
+        assert_eq!(original_size, unsafe {
+            (*list.size).load(Ordering::SeqCst)
+        });
+        assert_eq!(original_counter, unsafe {
+            (*list.counter).load(Ordering::SeqCst)
+        });
+        assert!(bm.check_buffer_returned());
     }
 }

--- a/src/buffer/slice.rs
+++ b/src/buffer/slice.rs
@@ -196,6 +196,7 @@ impl BufferSlice {
         if is_from_shm && let Some(buffer_header) = header {
             s.cap = buffer_header.cap();
             s.start = buffer_header.start();
+            s.read_index = s.start as usize;
             s.write_index = (s.start + buffer_header.size()) as usize;
             s.buffer_header = Some(buffer_header);
         } else {
@@ -226,6 +227,7 @@ impl BufferSlice {
             buffer_header.set_start(0);
             buffer_header.clear_flag()
         }
+        self.start = 0;
         self.write_index = 0;
         self.read_index = 0;
         self.next_slice = None;

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ impl Config {
         Self::default()
     }
 
-    pub fn verify(&self) -> Result<(), anyhow::Error> {
+    pub fn verify(&mut self) -> Result<(), anyhow::Error> {
         if self.share_memory_buffer_cap < (1 << 20) {
             return Err(anyhow!(
                 "share memory size is too small:{}, must greater than {}",
@@ -104,7 +104,7 @@ impl Config {
         }
 
         let mut sum = 0;
-        for pair in self.buffer_slice_sizes.iter() {
+        for pair in self.buffer_slice_sizes.iter_mut() {
             sum += pair.percent;
             if pair.size > self.share_memory_buffer_cap {
                 return Err(anyhow!(
@@ -114,11 +114,9 @@ impl Config {
                 ));
             }
 
-            #[cfg(target_arch = "aarch64")]
-            if pair.size % 4 != 0 {
-                return Err(anyhow!(
-                    "the size_percent_pair.size must be a multiple of 4"
-                ));
+            let aligned = (pair.size + 3) & !3;
+            if aligned != pair.size {
+                pair.size = aligned;
             }
         }
 
@@ -128,9 +126,9 @@ impl Config {
             ));
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if self.queue_cap % 8 != 0 {
-            return Err(anyhow!("the queue_cap must be a multiple of 8"));
+        let aligned_queue_cap = (self.queue_cap + 7) & !7;
+        if aligned_queue_cap != self.queue_cap {
+            self.queue_cap = aligned_queue_cap;
         }
 
         if self.share_memory_path_prefix.is_empty() || self.queue_path.is_empty() {
@@ -148,5 +146,34 @@ impl Config {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, SizePercentPair};
+
+    #[test]
+    fn verify_aligns_buffer_slice_sizes_and_queue_cap() {
+        let mut config = Config {
+            queue_cap: 8193,
+            buffer_slice_sizes: vec![
+                SizePercentPair {
+                    size: 4097,
+                    percent: 50,
+                },
+                SizePercentPair {
+                    size: 8193,
+                    percent: 50,
+                },
+            ],
+            ..Config::default()
+        };
+
+        config.verify().unwrap();
+
+        assert_eq!(8200, config.queue_cap);
+        assert_eq!(4100, config.buffer_slice_sizes[0].size);
+        assert_eq!(8196, config.buffer_slice_sizes[1].size);
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -163,18 +163,32 @@ impl Stream {
                 let slice = match self.session.shared.buffer_manager.read_buffer_slice(offset) {
                     Ok(slice) => slice,
                     Err(err) => {
-                        // it means that something bug about protocol occurred, underlying
-                        // connection will be closed.
                         tracing::error!("read_buffer_slice error {err}");
                         break;
                     }
                 };
-                if !slice
+                let has_next = slice
                     .buffer_header
                     .as_ref()
                     .map(|h| h.has_next())
-                    .unwrap_or(false)
-                {
+                    .unwrap_or(false);
+                if slice.size() == 0 {
+                    let next_offset = slice.buffer_header.as_ref().unwrap().next_buffer_offset();
+                    self.session.shared.buffer_manager.recycle_buffer(slice);
+                    if has_next {
+                        offset = next_offset;
+                        continue;
+                    } else {
+                        if let Some(back) = buf.slice_list().back()
+                            && let Some(bh) = &back.buffer_header
+                        {
+                            bh.clear_flag();
+                            bh.set_in_used();
+                        }
+                        break;
+                    }
+                }
+                if !has_next {
                     buf.append_buffer_slice(slice);
                     break;
                 }
@@ -195,18 +209,23 @@ impl Stream {
         err: Error,
         send_buf: &mut LinkedBuffer,
     ) -> Result<(), Error> {
+        let buf_len = send_buf.len();
+        if buf_len > u32::MAX as usize - 16 {
+            send_buf.recycle();
+            return Err(Error::NoMoreBuffer);
+        }
         tracing::warn!(
             "session {} stream fallback seqID:{} len:{} reason:{}, send_buf.is_from_share_memory: \
              {}",
             self.session.shared.name,
             self.id,
-            send_buf.len(),
+            buf_len,
             err,
             send_buf.is_from_share_memory()
         );
         let mut event = FallbackDataEvent([0u8; 16].as_mut_ptr());
         event.encode(
-            send_buf.len() as u32 + 16,
+            buf_len as u32 + 16,
             self.session.shared.communication_version,
             self.id,
             stream_status,
@@ -378,26 +397,28 @@ impl Stream {
         if self.session.shared.shutdown.load(Ordering::SeqCst) == 1 {
             return Ok(());
         }
-        // notify peer
-        if self
-            .session
-            .shared
-            .queue_manager
-            .send_queue
-            .put(QueueElement {
-                seq_id: self.id,
-                offset_in_shm_buf: 0,
-                status: STREAM_CLOSED,
-            })
-            .is_ok()
-        {
-            return self.session.wake_up_peer().await;
+        if !self.inner.in_fallback_state.load(Ordering::SeqCst) {
+            if self
+                .session
+                .shared
+                .queue_manager
+                .send_queue
+                .put(QueueElement {
+                    seq_id: self.id,
+                    offset_in_shm_buf: 0,
+                    status: STREAM_CLOSED,
+                })
+                .is_ok()
+            {
+                return self.session.wake_up_peer().await;
+            }
+            self.session
+                .shared
+                .stats
+                .queue_full_error_count
+                .fetch_add(1, Ordering::SeqCst);
         }
-        self.session
-            .shared
-            .stats
-            .queue_full_error_count
-            .fetch_add(1, Ordering::SeqCst);
+
         // notify close
         let mut event = vec![0u8; 12];
         unsafe {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -89,6 +89,54 @@ async fn test_ping_pong_by_shmipc() {
     println!("elapsed: {:?}", elapsed);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fallback_data_before_stream_close() {
+    let rand = rand::random::<u64>();
+    let path = format!("/dev/shm/shmipc{}.sock", rand);
+    let size = 2 << 20;
+    let mut sm_config = benchmark_config();
+
+    sm_config.config_mut().share_memory_buffer_cap = 1 << 20;
+    sm_config.config_mut().buffer_slice_sizes = vec![SizePercentPair {
+        size: 4096,
+        percent: 100,
+    }];
+    sm_config
+        .config_mut()
+        .share_memory_path_prefix
+        .push_str(rand.to_string().as_str());
+    sm_config = sm_config.with_session_num(1);
+
+    let mut server = Listener::new(
+        DefaultUnixListen,
+        SocketAddr::from_pathname(path.clone()).unwrap(),
+        sm_config.config().clone(),
+    )
+    .await
+    .unwrap();
+
+    tokio_scoped::scope(|s| {
+        s.spawn(async move {
+            let mut stream = server.accept().await.unwrap();
+            assert!(must_read(&mut stream, size).await);
+            assert!(!must_read(&mut stream, 1).await);
+        });
+        s.spawn(async move {
+            let client = SessionManager::new(
+                sm_config,
+                DefaultUnixConnect,
+                SocketAddr::from_pathname(path).unwrap(),
+            )
+            .await
+            .unwrap();
+            let mut stream = client.get_stream().unwrap();
+            must_write(&mut stream, size).await;
+            assert!(stream.fallback_state());
+            stream.close().await.unwrap();
+        });
+    });
+}
+
 fn benchmark_config() -> SessionManagerConfig {
     let mut c = SessionManagerConfig::new();
     c.config_mut().queue_cap = 65536;


### PR DESCRIPTION
## Summary

This PR fixes several edge cases in shared-memory buffer handling, fallback writes, stream close ordering, and configuration alignment. It also updates CI runner settings so checks run on hosted infrastructure.

## Bug Fixes

### Shared-memory read correctness

- Initialize a mapped buffer slice's `read_index` from the stored `start` offset.
- Reset the stored `start` offset when a slice is reset, so reused slices do not keep stale read offsets.

### Pending-data slice handling

- Skip and recycle empty shared-memory slices while moving pending data into the receive buffer.
- Preserve the previous slice's link state when an empty tail slice is removed.

### Bounds and overflow safety

- Reject mapped shared-memory files or fds whose size cannot be represented by the buffer manager capacity.
- Avoid lossy signed/unsigned comparison in returned-buffer checks.
- Reject fallback writes that cannot fit in the frame length field before encoding the frame.

### Buffer recycling safety

- Skip recycling a shared-memory slice when it has no header or is no longer marked in use.
- Add a regression test covering duplicate recycle attempts against the same shared-memory offset.

### Fallback stream close ordering

- When a stream has entered fallback mode, send the close event over the UDS control path instead of the shared-memory queue.
- Add a regression test that forces fallback data, closes immediately, and verifies the receiver observes data before end-of-stream.

### Config alignment

- Auto-align `buffer_slice_sizes[*].size` to a 4-byte boundary during config verification.
- Auto-align `queue_cap` to an 8-byte boundary during config verification.
- Add a unit test covering both alignment paths.

## CI

- Move workflow jobs to hosted Linux runners.

## Validation

- `cargo +nightly fmt --check`
- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`